### PR TITLE
mconf: make sourcing relative of the sourcer file

### DIFF
--- a/expr.h
+++ b/expr.h
@@ -21,6 +21,7 @@ struct file {
 	struct file *next;
 	struct file *parent;
 	const char *name;
+	char *abs_name;
 	int lineno;
 };
 

--- a/util.c
+++ b/util.c
@@ -15,6 +15,7 @@ struct file *file_lookup(const char *name)
 {
 	struct file *file;
 	const char *file_name = sym_expand_string_value(name);
+	char *abs_file_name = realpath(file_name, NULL);
 
 	for (file = file_list; file; file = file->next) {
 		if (!strcmp(name, file->name)) {
@@ -26,6 +27,7 @@ struct file *file_lookup(const char *name)
 	file = malloc(sizeof(*file));
 	memset(file, 0, sizeof(*file));
 	file->name = file_name;
+	file->abs_name = abs_file_name;
 	file->next = file_list;
 	file_list = file;
 	return file;

--- a/zconf.tab.c
+++ b/zconf.tab.c
@@ -86,6 +86,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <limits.h>
+#include <libgen.h>
+
+#ifndef PATH_MAX
+# define PATH_MAX 4096
+#endif
 
 #include "lkc.h"
 
@@ -1418,6 +1424,8 @@ yyparse ()
     YYSTYPE *yyvsp;
 
     YYSIZE_T yystacksize;
+    char abs_path[PATH_MAX];
+    const char *path, *base;
 
   int yyn;
   int yyresult;
@@ -1900,8 +1908,11 @@ yyreduce:
   case 83:
 
     {
-	printd(DEBUG_PARSE, "%s:%d:source %s\n", zconf_curname(), zconf_lineno(), (yyvsp[(2) - (3)].string));
-	zconf_nextfile((yyvsp[(2) - (3)].string));
+	path = yyvsp[(2) - (3)].string;
+	base = dirname(current_file->abs_name);
+	snprintf(abs_path, sizeof(abs_path), "%s/%s", base, path);
+	printd(DEBUG_PARSE, "%s:%d:source %s\n", zconf_curname(), zconf_lineno(), path);
+	zconf_nextfile(abs_path);
 ;}
     break;
 


### PR DESCRIPTION
Sourcing of files was relative to the mconf program, not to the
sourcer file.