### PR TITLE
Fixing problems when including more than one subconfig

### DIFF
--- a/test/rootconf
+++ b/test/rootconf
@@ -89,3 +89,7 @@ config TRISTATE_PARAM
 menu "Subconfmenu"
 	source ../test/subconfig
 endmenu
+
+menu "Subconfmenu2"
+	source ../test/subconfig2
+endmenu

--- a/test/subconfig2
+++ b/test/subconfig2
@@ -1,0 +1,9 @@
+comment "This file can contain arbitrary nesting and dependencies and is always included"
+
+# This option is only configured if GEN_CHOICE2 is set
+if GEN_CHOICE2
+	config OPTIONAL_PARAM2
+		string
+		default "opt2"
+endif
+

--- a/zconf.tab.c
+++ b/zconf.tab.c
@@ -1908,8 +1908,10 @@ yyreduce:
   case 83:
 
     {
+	char tmp_abs_name[256];
 	path = yyvsp[(2) - (3)].string;
-	base = dirname(current_file->abs_name);
+	strncpy(tmp_abs_name, current_file->abs_name, 255);
+	base = dirname(tmp_abs_name);
 	snprintf(abs_path, sizeof(abs_path), "%s/%s", base, path);
 	printd(DEBUG_PARSE, "%s:%d:source %s\n", zconf_curname(), zconf_lineno(), path);
 	zconf_nextfile(abs_path);


### PR DESCRIPTION
Hello George,
I wanted to include (with "source") several subconfig files, but only the first was included correctly - at all others the computed path was wrong.

I figured out that there is a wrong use of dirname - which man-page state "Both dirname() and basename() may modify the contents of  path, so it may be desirable to pass a copy when calling one of these functions".

I ve tried to fix it...

Best regards, Karl
